### PR TITLE
Added option for Gulp logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Type: `String`
 
 Default: `    ` (4 spaces)
 
+### log
+
+Whether Gulp should log output i.e. `Generated sitemap.xml`
+
+Type: `Boolean`
+
+Default: `false`
+
 ## Example usage with default options
 
 ```js

--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ module.exports = function (params) {
         //set xml spacing. can be \t for tabs
         spacing: '    ',
         //set default priority
-        priority: '0.5'
+        priority: '0.5',
+        //whether to log output
+        log: false
     });
     //enforce priority to be a string
     config.priority = config.priority.toString();
@@ -91,7 +93,9 @@ module.exports = function (params) {
                 contents: new Buffer(sitemap.prepareSitemap(entries, config))
             }));
 
-            gutil.log('Generated', gutil.colors.blue(config.fileName));
+            if (config.log === true) {
+                gutil.log('Generated', gutil.colors.blue(config.fileName));
+            }
             return cb();
         });
 };


### PR DESCRIPTION
Typically Gulp plugins suppress the output of the native module and add an option to log the output. Basically:

``` js
.pipe(sitemap({
  log: true
}));
```

Gives the option of keeping the command line clean.
