### PR TITLE
Modify the loc with mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ hreflang: [{
 }]
 ```
 
+##### modifyloc
+
+Matching pages can get their `loc` tag modified by using a function.
+
+```js
+modifyloc: function(loc) {
+    return loc.substr(0, loc.lastIndexOf('.')) || loc; // Removes the file extension
+}
+```
+
 #### verbose
 
 Type: `boolean`

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -19,7 +19,7 @@ function getEntryConfig(file, fileLastMod, config) {
         return multimatch(file, item.pages).length > 0;
     }) || {};
 
-    var properties = ['lastmod', 'priority', 'changefreq', 'hreflang'];
+    var properties = ['modifyloc', 'lastmod', 'priority', 'changefreq', 'hreflang'];
 
     var entry = defaults(
         pick(mappingsForFile, properties),
@@ -58,11 +58,16 @@ function processEntry(entry, config) {
     var loc = entry.loc;
     var hreflang = entry.hreflang;
     var file = entry.file;
+    var modifyloc = entry.modifyloc;
 
     var returnArr = [
-        config.spacing + '<url>',
-        config.spacing + config.spacing + wrapTag('loc', loc)
+        config.spacing + '<url>'
     ];
+    if (modifyloc && typeof modifyloc === 'function') {
+        returnArr.push(config.spacing + config.spacing + wrapTag('loc', modifyloc(loc)));
+    } else {
+        returnArr.push(config.spacing + config.spacing + wrapTag('loc', loc));
+    }
     if (lastmod) {
         //format mtime to ISO (same as +00:00)
         lastmod = new Date(lastmod).toISOString();

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>http://www.amazon.com/</loc>
-        <lastmod>2015-07-28T17:49:55.000Z</lastmod>
+        <lastmod>2016-02-27T10:00:09.095Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.5</priority>
     </url>
     <url>
         <loc>http://www.amazon.com/test.html</loc>
-        <lastmod>2015-07-28T17:49:55.000Z</lastmod>
+        <lastmod>2016-02-27T10:00:09.100Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.5</priority>
     </url>
     <url>
         <loc>http://www.amazon.com/nested/article.html</loc>
-        <lastmod>2015-07-28T17:49:55.000Z</lastmod>
+        <lastmod>2016-02-27T10:00:09.099Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.5</priority>
     </url>

--- a/test/mappings.spec.js
+++ b/test/mappings.spec.js
@@ -200,4 +200,24 @@ describe('mappings', function() {
         stream.write(new gutil.File(dummyFile));
         stream.end();
     });
+
+    it('should modify the loc with mappings', function(cb) {
+        var stream = sitemap({
+            siteUrl: 'http://www.amazon.com',
+            mappings: [{
+                pages: ['*/*test.html'],
+                modifyloc: function(loc) {
+                    return loc.substr(0, loc.lastIndexOf('.')) || loc; // Removes the file extension
+                }
+            }]
+        });
+
+        stream.on('data', function(data) {
+            var contents = data.contents.toString();
+            contents.should.match(/\/test<\/loc>/i);
+        }).on('end', cb);
+
+        stream.write(new gutil.File(dummyFile));
+        stream.end();
+    });
 });


### PR DESCRIPTION
You can now modify the loc tag with mappings by passing it to a function.

Example:

    mappings: [
        {
            pages: [ 'minimatch pattern' ],
            modifyloc: function(loc) {
                return loc.substr(0, loc.lastIndexOf('.')) || loc; // Removes the file extension
            }
        }
    ]