### PR TITLE
Fixes JSDoc warning

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -50,7 +50,7 @@ function wrapTag(tag, value) {
  * processEntry
  *
  * @param entry
- * @param config
+ * @param siteConfig
  * @return {Array}
  */
 function processEntry(entry, siteConfig) {


### PR DESCRIPTION
Fixes JSDoc warning.

I have seen that there is no real JSDoc documentation as of yet, but my IDE was warning about this one.