### PR TITLE
Allow lastmod to be a command that is executed for the current entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,24 @@ The file last modified time.
 
  If `null` then this plugin will try to get the last modified time from the stream vinyl file, or use `Date.now()` as lastmod.
 
-If the value is not `null` - It will be used as lastmod. That gives the user the ability to manually set the `lastmod`.
+If the value is not `null` - It will be used as lastmod. When `lastmod` is a function, it is executed in the context of the current file. A string can be used to manually set a fixed `lastmod`.
 
-Type: `string|Datetime`
+Type: `string|Datetime|Function`
 
 Default: `null`
 
 Required: `false`
+
+Example that uses git to get lastmod from the latest commit of a file:
+
+```js
+lastmod: function(file) {
+  var cmd = 'git log -1 --format=%cI "' + file.relative + '"';
+  return execSync(cmd, {
+    cwd: file.base
+  }).toString().trim();
+}
+```
 
 **Note: any falsey (other than null) value is also valid and will skip this xml tag**
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,3 +13,16 @@ gulp.task('default', function () {
         }))
         .pipe(gulp.dest('./'));
 });
+
+gulp.task('git', function () {
+    gulp.src('test/fixtures/**/*.html', {
+            read: false
+        })
+        .pipe(sitemap({
+            siteUrl: 'http://www.amazon.com/',
+            priority: '0.5',
+            changefreq: 'weekly',
+            lastmod: 'git log -1 --format=%cI $1'
+        }))
+        .pipe(gulp.dest('./'));
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 'use strict';
 var gulp = require('gulp');
 var sitemap = require('./index');
+var execSync = require('child_process').execSync;
 
 gulp.task('default', function () {
     gulp.src('test/fixtures/**/*.html', {
@@ -29,6 +30,24 @@ gulp.task('hreflang', function () {
                   return 'http://www.amazon.ru/' + file;
               }
             }]
+        }))
+        .pipe(gulp.dest('./'));
+});
+
+gulp.task('git', function () {
+    gulp.src('test/fixtures/**/*.html', {
+            read: false
+        })
+        .pipe(sitemap({
+            siteUrl: 'http://www.amazon.com/',
+            priority: '0.5',
+            changefreq: 'weekly',
+            lastmod: function(file) {
+              var cmd = 'git log -1 --format=%cI "' + file.relative + '"';
+              return execSync(cmd, {
+                cwd: file.base
+              }).toString().trim();
+            }
         }))
         .pipe(gulp.dest('./'));
 });

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function (options) {
                 firstFile = file;
             }
             var mtime = file.stat ? file.stat.mtime : null;
-            var entry = sitemap.getEntryConfig(file.relative, mtime, config);
+            var entry = sitemap.getEntryConfig(file, mtime, config);
             entries.push(entry);
             callback();
         },

--- a/index.js
+++ b/index.js
@@ -55,8 +55,8 @@ module.exports = function (options) {
             if (!firstFile) {
                 firstFile = file;
             }
-            var mtime = file.stat ? file.stat.mtime : null;
-            var entry = sitemap.getEntryConfig(file, mtime, config);
+
+            var entry = sitemap.getEntryConfig(file, config);
             entries.push(entry);
             callback();
         },

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -5,6 +5,7 @@ var includes = require('lodash/includes');
 var multimatch = require('multimatch');
 var slash = require('slash');
 var pick = require('lodash/pick');
+var execSync = require('child_process').execSync;
 
 //TODO: export this to an external module
 var header = [
@@ -14,7 +15,8 @@ var header = [
 
 var footer = ['</urlset>'];
 
-function getEntryConfig(file, fileLastMod, siteConfig) {
+function getEntryConfig(fileObject, fileLastMod, siteConfig) {
+    var file = fileObject.relative;
     var mappingsForFile = find(siteConfig.mappings, function(item) {
         return multimatch(file, item.pages).length > 0;
     }) || {};
@@ -28,6 +30,14 @@ function getEntryConfig(file, fileLastMod, siteConfig) {
 
     if (entry.lastmod === null) {
         entry.lastmod = fileLastMod || Date.now();
+    } else if (typeof entry.lastmod === 'string' && !isDateValid(entry.lastmod)) {
+        // assume it's a command
+        var cmd = entry.lastmod.replace('$1', fileObject.relative);
+        var output = execSync(cmd, {
+            cwd: fileObject.base
+        }).toString().trim();
+
+        entry.lastmod = isDateValid(output) ? output : Date.now();
     }
 
     //turn index.html into -> /
@@ -116,6 +126,11 @@ function isChangefreqValid(changefreq) {
         return true;
     }
     return includes(validChangefreqs, changefreq.toLowerCase());
+}
+
+function isDateValid(str) {
+    var date = new Date(str);
+    return Object.prototype.toString.call(date) === "[object Date]" && !isNaN(date.getTime());
 }
 
 exports.getEntryConfig = getEntryConfig;

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -30,7 +30,7 @@ function getEntryConfig(fileObject, fileLastMod, siteConfig) {
 
     if (entry.lastmod === null) {
         entry.lastmod = fileLastMod || Date.now();
-    } else if (typeof entry.lastmod === 'string' && !isDateValid(entry.lastmod)) {
+    } else if (entry.lastmod && !isDateValid(entry.lastmod)) {
         // assume it's a command
         var cmd = entry.lastmod.replace('$1', fileObject.relative);
         var output = execSync(cmd, {

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -5,7 +5,6 @@ var includes = require('lodash/includes');
 var multimatch = require('multimatch');
 var slash = require('slash');
 var pick = require('lodash/pick');
-var execSync = require('child_process').execSync;
 
 //TODO: export this to an external module
 var header = [
@@ -20,7 +19,7 @@ var headerHref = [
 
 var footer = ['</urlset>'];
 
-function getEntryConfig(fileObject, fileLastMod, siteConfig) {
+function getEntryConfig(fileObject, siteConfig) {
     var file = fileObject.relative;
     var mappingsForFile = find(siteConfig.mappings, function(item) {
         return multimatch(file, item.pages).length > 0;
@@ -34,15 +33,9 @@ function getEntryConfig(fileObject, fileLastMod, siteConfig) {
     );
 
     if (entry.lastmod === null) {
-        entry.lastmod = fileLastMod || Date.now();
-    } else if (entry.lastmod && !isDateValid(entry.lastmod)) {
-        // assume it's a command
-        var cmd = entry.lastmod.replace('$1', fileObject.relative);
-        var output = execSync(cmd, {
-            cwd: fileObject.base
-        }).toString().trim();
-
-        entry.lastmod = isDateValid(output) ? output : Date.now();
+        entry.lastmod = fileObject.stat && fileObject.stat.mtime || Date.now();
+    } else if (typeof entry.lastmod === 'function') {
+        entry.lastmod = entry.lastmod(fileObject);
     }
 
     //turn index.html into -> /
@@ -134,11 +127,6 @@ function isChangefreqValid(changefreq) {
         return true;
     }
     return includes(validChangefreqs, changefreq.toLowerCase());
-}
-
-function isDateValid(str) {
-    var date = new Date(str);
-    return Object.prototype.toString.call(date) === "[object Date]" && !isNaN(date.getTime());
 }
 
 exports.getEntryConfig = getEntryConfig;


### PR DESCRIPTION
Implements #12.

Could you please review @pgilad?

I'm not sure about the API. Now, it is detected whether the current `lastmod` string is a date or not. If it's not, it's assumed to be a command. Would it be better to add a property like e.g. `lastmodcmd`?