### PR TITLE
Add read:false to example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ var gulp = require('gulp');
 var sitemap = require('gulp-sitemap');
 
 gulp.task('sitemap', function () {
-    gulp.src('build/**/*.html')
+    gulp.src('build/**/*.html', {
+            read: false
+        })
         .pipe(sitemap({
             siteUrl: 'http://www.amazon.com'
         }))
@@ -45,7 +47,9 @@ var sitemap = require('gulp-sitemap');
 var save = require('gulp-save');
 
 gulp.task('html', function() {
-    gulp.src('*.html')
+    gulp.src('*.html', {
+          read: false
+        })
         .pipe(save('before-sitemap'))
         .pipe(sitemap({
                 siteUrl: 'http://www.amazon.com'


### PR DESCRIPTION
Implements #14. 

I think what is does is self-explanatory, but when one does not know that this option exists it's good that is included in the examples.