### PR TITLE
Fix index.html recognition in Windows

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -38,7 +38,7 @@ function getEntryConfig(file, siteConfig) {
         entry.lastmod = entry.lastmod(file);
     }
 
-    var indexRegex = /(\/|^)index\.html?$/;
+    var indexRegex = /(\/|\\|^)index\.html?$/;
     //turn index.html into -> /
     var relativeFile = relativePath.replace(indexRegex, function(string, match) {
         return match.slice(0, 1) === '/' ? '/' : '';


### PR DESCRIPTION
Use two different path delimiters to recognize forward and backward slash path delimiters followed by 'index.html'