### PR TITLE
Fix the logic of index.htm(l) removing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 /node_modules
 /nested

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -38,11 +38,8 @@ function getEntryConfig(file, siteConfig) {
         entry.lastmod = entry.lastmod(file);
     }
 
-    var indexRegex = /(\/|\\|^)index\.html?$/;
     //turn index.html into -> /
-    var relativeFile = relativePath.replace(indexRegex, function(string, match) {
-        return match.slice(0, 1) === '/' ? '/' : '';
-    }, 'i');
+    var relativeFile = relativePath.replace(/(\/|\\|^)index\.html?$/, '/');
     //url location. Use slash to convert windows \\ or \ to /
     var adjustedFile = slash(relativeFile);
     entry.loc = siteConfig.siteUrl + adjustedFile;

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -122,6 +122,7 @@ describe('general settings', function () {
             contents.should.containEql('test.html');
             contents.should.containEql('nested/article.html');
             contents.should.containEql('another_index.html');
+            contents.should.containEql('<loc>http://www.amazon.com/nested/</loc>');
             contents.should.not.containEql('404.html');
             contents.should.not.containEql('home.html');
             contents.should.not.containEql(/\/index.html/);


### PR DESCRIPTION
The old logic removes the /index.htm(l) part with the trailing slash. Thus http://domain/index.html becomes http://domain as well as http://domain/info/index.html becomes http://domain/info - without trailing slash. Is's bad for SEO because it requires additional redirect from the serve and it can slow down site indexation.

Let's fix this issue.