### PR TITLE
Replace gulp-util with smaller modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 'use strict';
 var chalk = require('chalk');
 var defaults = require('lodash/defaults');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var path = require('path');
+var PluginError = require('plugin-error');
 var through = require('through2');
+var Vinyl = require('vinyl');
 
 var pluginName = 'gulp-sitemap';
 var sitemap = require('./lib/sitemap');
@@ -14,7 +16,7 @@ module.exports = function (options) {
         fileName: 'sitemap.xml',
         lastmod: null,
         mappings: [],
-        newLine: gutil.linefeed,
+        newLine: '\n',
         priority: undefined,
         spacing: '    ',
         verbose: false
@@ -25,11 +27,11 @@ module.exports = function (options) {
 
     if (!config.siteUrl) {
         msg = 'siteUrl is a required param';
-        throw new gutil.PluginError(pluginName, msg);
+        throw new PluginError(pluginName, msg);
     }
     if (options.changeFreq) {
         msg = chalk.magenta('changeFreq') + ' has been deprecated. Please use ' + chalk.cyan('changefreq');
-        throw new gutil.PluginError(pluginName, msg);
+        throw new PluginError(pluginName, msg);
     }
     // site url should have a trailing slash
     if (config.siteUrl.slice(-1) !== '/') {
@@ -44,7 +46,7 @@ module.exports = function (options) {
 
             if (file.isStream()) {
                 msg = 'Streaming not supported';
-                return callback(new gutil.PluginError(pluginName), msg);
+                return callback(new PluginError(pluginName), msg);
             }
 
             //skip 404 file
@@ -67,10 +69,10 @@ module.exports = function (options) {
             var contents = sitemap.prepareSitemap(entries, config);
             if (options.verbose) {
                 msg = 'Files in sitemap: ' + entries.length;
-                gutil.log(pluginName, msg);
+                log(pluginName, msg);
             }
             //create and push new vinyl file for sitemap
-            this.push(new gutil.File({
+            this.push(new Vinyl({
                 cwd: firstFile.cwd,
                 base: firstFile.cwd,
                 path: path.join(firstFile.cwd, config.fileName),

--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
   ],
   "dependencies": {
     "chalk": "^1.1.1",
-    "gulp-util": "^3.0.7",
+    "fancy-log": "^1.3.2",
     "lodash": "^4.6.1",
     "multimatch": "^2.0.0",
+    "plugin-error": "^0.1.2",
     "slash": "^1.0.0",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "gulp": "^3.8.11",

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -4,10 +4,10 @@ var fs = require('fs');
 
 var chalk = require('chalk');
 var gulp = require('gulp');
-var gutil = require('gulp-util');
 var rename = require('gulp-rename');
 var should = require('should');
 var sitemap = require('../index');
+var Vinyl = require('vinyl');
 
 describe('general settings', function () {
     var testFile = {
@@ -52,7 +52,7 @@ describe('general settings', function () {
         stream.on('end', cb);
         expectedLastmod = fs.statSync(testedFile).mtime;
 
-        stream.write(new gutil.File({
+        stream.write(new Vinyl({
             cwd: __dirname,
             base: __dirname,
             path: testedFile,
@@ -76,7 +76,7 @@ describe('general settings', function () {
             contents.should.not.containEql('<lastmod>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(testFile));
+        stream.write(new Vinyl(testFile));
         stream.end();
     });
 
@@ -91,7 +91,7 @@ describe('general settings', function () {
             contents.should.not.containEql('<changefreq>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(testFile));
+        stream.write(new Vinyl(testFile));
         stream.end();
     });
 
@@ -106,7 +106,7 @@ describe('general settings', function () {
             contents.should.not.containEql('<priority>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(testFile));
+        stream.write(new Vinyl(testFile));
         stream.end();
     });
 
@@ -144,7 +144,7 @@ describe('general settings', function () {
             contents.should.containEql('<lastmod>' + time + '</lastmod>');
         }).on('end', cb);
 
-        stream.write(new gutil.File({
+        stream.write(new Vinyl({
             cwd: __dirname,
             base: __dirname,
             path: 'test/fixtures/test.html',
@@ -189,8 +189,8 @@ describe('general settings', function () {
             contents: new Buffer('hello there')
         };
 
-        stream.write(new gutil.File(testFile));
-        stream.write(new gutil.File(testFile2));
+        stream.write(new Vinyl(testFile));
+        stream.write(new Vinyl(testFile2));
         stream.end();
     });
 

--- a/test/mappings.spec.js
+++ b/test/mappings.spec.js
@@ -1,8 +1,8 @@
 /* global it,describe */
 'use strict';
 var should = require('should');
-var gutil = require('gulp-util');
 var sitemap = require('../index');
+var Vinyl = require('vinyl');
 
 describe('mappings', function() {
 
@@ -36,7 +36,7 @@ describe('mappings', function() {
             contents.should.containEql('<priority>0.5</priority>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -61,7 +61,7 @@ describe('mappings', function() {
             contents.should.containEql('<priority>0.4</priority>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -85,7 +85,7 @@ describe('mappings', function() {
             contents.should.containEql('<priority>0.4</priority>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -104,7 +104,7 @@ describe('mappings', function() {
             contents.should.not.containEql('<priority>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -124,7 +124,7 @@ describe('mappings', function() {
             contents.should.containEql('<priority>0</priority>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -143,7 +143,7 @@ describe('mappings', function() {
             contents.should.not.containEql('<lastmod>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -164,7 +164,7 @@ describe('mappings', function() {
             contents.should.containEql('<lastmod>' + time + '</lastmod>');
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -197,7 +197,7 @@ describe('mappings', function() {
             contents.should.match(/www.amazon.de/i);
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 
@@ -217,7 +217,7 @@ describe('mappings', function() {
             contents.should.match(/\/test<\/loc>/i);
         }).on('end', cb);
 
-        stream.write(new gutil.File(dummyFile));
+        stream.write(new Vinyl(dummyFile));
         stream.end();
     });
 });


### PR DESCRIPTION
Gulp-util has been deprecated. Removing the dependency future-proofs gulp-sitemaps in view of the upcoming gulp 4.0 release.