### PR TITLE
change `new Buffer` to `Buffer.from`

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = function (options) {
                 cwd: firstFile.cwd,
                 base: firstFile.cwd,
                 path: path.join(firstFile.cwd, config.fileName),
-                contents: new Buffer(contents)
+                contents: Buffer.from(contents)
             }));
             callback();
         });


### PR DESCRIPTION
`new Buffer` has been deprecated in node 10 (https://github.com/nodejs/node/pull/8169)