### PR TITLE
Loosen image matching regex

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -77,7 +77,7 @@ function notIsHTTPURL(text) {
 }
 
 function getImagesUrl(entry, siteConfig) {
-    const reImageMatch = /<img\s+src="((https?:\/\/)?[\w\.\/]+)"\s+alt="[\w\.a/]*"\/?>/ig;
+    const reImageMatch = /<img\s+src="((https?:\/\/)?[\w\.\/]+)"/ig;
     const reSourceMatch = /"((https?:\/\/)?[\w\.\/]+)"/ig;
     const html = fs.readFileSync(entry.source, { encoding : 'utf8'})
     const images = html.match(reImageMatch);

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -9,7 +9,7 @@ const pick = require('lodash/pick');
 
 const header = [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">'
 ];
 
 const headerHref = [

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -8,6 +8,7 @@
     <img src="assets/images/placeholder.jpg" alt="">
     <img src="/assets/images/placeholder.jpg" alt="">
     <img src="./assets/images/placeholder.jpg" alt="">
+    <img src="assets/images/placeholder_small.jpg" srcset="/assets/placeholder_small.jpg 400w, /assets/placeholder_large.jpg 800w" sizes="100vw" alt="">
     <img src="https://via.placeholder.com/300/09f/000.png" alt="">
     <img src="https://via.placeholder.com/300/09f/f5f.png" alt="">
 </body>

--- a/test/mappings.spec.js
+++ b/test/mappings.spec.js
@@ -239,12 +239,13 @@ describe('mappings', function() {
 
         stream.on('data', function(data) {
             const contents = data.contents.toString();
-
+            
             contents.should.containEql('<image:loc>https://via.placeholder.com/300/09f/fff.png</image:loc>');
             contents.should.containEql('<image:loc>http://www.amazon.com/assets/images/placeholder.jpg</image:loc>');
             contents.should.containEql('<image:loc>https://via.placeholder.com/300/09f/000.png</image:loc>');
             contents.should.containEql('<image:loc>https://via.placeholder.com/300/09f/f5f.png</image:loc>');
-
+            contents.should.containEql('<image:loc>http://www.amazon.com/assets/images/placeholder_small.jpg</image:loc>');
+            
         }).on('end', cb);
 
         stream.write(new Vinyl(dummyFile));


### PR DESCRIPTION
Loosened the image matching regex to allow for use of additional attributes (i.e. srcset) on img elements. Only requirement for matching is that the src attribute follows the opening of an img element. In addition I added the image namespace definition to the default header.